### PR TITLE
Generic ElasticSearch producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,18 +105,18 @@ The detailed description of each parameter:
    *example:*
       ```json
        "_source": {
-                      "name": "John",
-                      "age": 28
-                   }
+          "name": "John",
+          "age": 28
+       }
       ```
    
    - `string` : Inserts string message into ES as a documet, where the key name is `value`, and the value is the received message.
    *example:*
-   ```json
-    "_source": {
-                   "value": "received text message"
-                }
-   ```
+    ```json
+     "_source": {
+          "value": "received text message"
+     }
+    ```
    
 * `index` (optional) - The name of elasticsearch index. Default is: `kafka-index`
 * `type` (optional) - The mapping type of elasticsearch index. Default is: `status`

--- a/README.md
+++ b/README.md
@@ -126,6 +126,21 @@ The detailed description of each parameter:
    - `index` : Creates documents in ES with the `value` field set to the received message.
    - `delete` : Deletes documents from ES based on `id` field set in the received message.
    - `raw.execute` : Execute incoming messages as a raw query.
+   - `generic.request` : Encapsulate generic request in Json. Currently supported are Bulk and Delete by query. Here are the accepted Json queries :
+
+```
+{
+	"type":"bulk",
+	"content":"{\"index\":{\"_index\":\"test\",\"_type\":\"type1\",\"_id\":\"1\"}}\n{\"field1\":\"value1\"}"
+}
+
+or
+
+{
+	"type":"delete_by_query",
+	"query":"{\"query\":{\"match_all\":{}}}"
+}
+```
 
 Flush interval is set to 12 hours by default, so any remaining messages get flushed to elasticsearch even if the number of messages has not reached. 
 

--- a/src/main/java/org/elasticsearch/river/kafka/ElasticSearchProducer.java
+++ b/src/main/java/org/elasticsearch/river/kafka/ElasticSearchProducer.java
@@ -42,7 +42,7 @@ public abstract class ElasticSearchProducer {
 
     protected final ObjectReader reader = new ObjectMapper().reader(new TypeReference<Map<String, Object>>() {});
 
-    private Client client;
+    protected Client client;
     protected BulkProcessor bulkProcessor;
 
     protected RiverConfig riverConfig;

--- a/src/main/java/org/elasticsearch/river/kafka/GenericRequestProducer.java
+++ b/src/main/java/org/elasticsearch/river/kafka/GenericRequestProducer.java
@@ -17,6 +17,8 @@ import java.util.Set;
  * This producer takes  a JSon representing an ElasticSearch request.
  *
  * It was added to support non bulkable operations that we would like to manage threw a Kafka queue. For instance delete by query.
+ *
+ * @author Benoit Tellier from Linagora
  */
 public class GenericRequestProducer extends ElasticSearchProducer {
 
@@ -66,6 +68,7 @@ public class GenericRequestProducer extends ElasticSearchProducer {
                     logger.warn("Unknown TYPE provided");
                 }
             } catch (Exception ex) {
+                logger.error("Exception", ex);
                 ex.printStackTrace();
             }
         }

--- a/src/main/java/org/elasticsearch/river/kafka/GenericRequestProducer.java
+++ b/src/main/java/org/elasticsearch/river/kafka/GenericRequestProducer.java
@@ -1,0 +1,73 @@
+package org.elasticsearch.river.kafka;
+
+import kafka.message.MessageAndMetadata;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.bytes.ChannelBufferBytesReference;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
+import org.elasticsearch.common.netty.buffer.ByteBufferBackedChannelBuffer;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This producer takes  a JSon representing an ElasticSearch request.
+ *
+ * It was added to support non bulkable operations that we would like to manage threw a Kafka queue. For instance delete by query.
+ */
+public class GenericRequestProducer extends ElasticSearchProducer {
+
+    public final static String TYPE = "type";
+    public final static String QUERY = "query";
+    public final static String BULK = "bulk";
+    public final static String DELETE_BY_QUERY = "delete_by_query";
+    public final static String CONTENT = "content";
+
+    private static final ESLogger logger = ESLoggerFactory.getLogger(GenericRequestProducer.class.getName());
+
+    public GenericRequestProducer (Client client, RiverConfig riverConfig, KafkaConsumer kafkaConsumer) {
+        super(client, riverConfig, kafkaConsumer);
+    }
+
+    /**
+     * For the given messages creates delete document requests and adds them to the bulk processor queue, for
+     * processing later when the size of bulk actions is reached.
+     *
+     * @param messageSet given set of messages
+     */
+    public void addMessagesToBulkProcessor(final Set<MessageAndMetadata> messageSet) {
+
+
+        for (MessageAndMetadata messageAndMetadata : messageSet) {
+            final byte[] messageBytes = (byte[]) messageAndMetadata.message();
+
+            if (messageBytes == null || messageBytes.length == 0) return;
+
+            try {
+                XContentParser parser = JsonXContent.jsonXContent.createParser(messageBytes);
+                Map<String, Object> keys = parser.mapAndClose();
+                String type = (String) keys.get(TYPE);
+                if (type.equalsIgnoreCase(BULK)) {
+                    String content = (String) keys.get(CONTENT);
+                    ByteBuffer byteBuffer = ByteBuffer.wrap(content.getBytes());
+                    bulkProcessor.add(
+                            new ChannelBufferBytesReference(new ByteBufferBackedChannelBuffer(byteBuffer)),
+                            false,
+                            riverConfig.getIndexName(),
+                            riverConfig.getTypeName()
+                    );
+                } else if (type.equalsIgnoreCase(DELETE_BY_QUERY) ) {
+                    String queryString = (String) keys.get(QUERY);
+                    client.prepareDeleteByQuery().setSource(queryString).execute();
+                } else {
+                    logger.warn("Unknown TYPE provided");
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/org/elasticsearch/river/kafka/KafkaRiver.java
+++ b/src/main/java/org/elasticsearch/river/kafka/KafkaRiver.java
@@ -54,6 +54,9 @@ public class KafkaRiver extends AbstractRiverComponent implements River {
             case RAW_EXECUTE:
                 elasticsearchProducer = new RawMessageProducer(client, riverConfig, kafkaConsumer);
                 break;
+            case GENERIC_REQUEST:
+                elasticsearchProducer = new GenericRequestProducer(client, riverConfig, kafkaConsumer);
+                break;
         }
     }
 

--- a/src/main/java/org/elasticsearch/river/kafka/KafkaRiver.java
+++ b/src/main/java/org/elasticsearch/river/kafka/KafkaRiver.java
@@ -23,9 +23,6 @@ import org.elasticsearch.river.River;
 import org.elasticsearch.river.RiverName;
 import org.elasticsearch.river.RiverSettings;
 
-import static org.elasticsearch.river.kafka.RiverConfig.*;
-import static org.elasticsearch.river.kafka.RiverConfig.ActionType.*;
-
 /**
  * This is the actual river implementation, which starts a thread to read messages from kafka and put them into elasticsearch.
  */

--- a/src/main/java/org/elasticsearch/river/kafka/RiverConfig.java
+++ b/src/main/java/org/elasticsearch/river/kafka/RiverConfig.java
@@ -93,7 +93,8 @@ public class RiverConfig {
 
         INDEX("index"),
         DELETE("delete"),
-        RAW_EXECUTE("raw.execute");
+        RAW_EXECUTE("raw.execute"),
+        GENERIC_REQUEST("generic.request");
 
         private String actionType;
 

--- a/src/main/java/org/elasticsearch/river/kafka/RiverConfig.java
+++ b/src/main/java/org/elasticsearch/river/kafka/RiverConfig.java
@@ -15,6 +15,8 @@
  */
 package org.elasticsearch.river.kafka;
 
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.river.RiverName;
 import org.elasticsearch.river.RiverSettings;
@@ -41,6 +43,7 @@ public class RiverConfig {
     private static final String CONCURRENT_REQUESTS = "concurrent.requests";
     private static final String ACTION_TYPE = "action.type";
 
+    private static final ESLogger logger = ESLoggerFactory.getLogger(RiverConfig.class.getName());
 
     private String zookeeperConnect;
     private int zookeeperConnectionTimeout;
@@ -110,8 +113,9 @@ public class RiverConfig {
             if(value == null) throw new IllegalArgumentException();
 
             for(ActionType values : values()) {
-                if(value.equalsIgnoreCase(values.toValue()))
+                if(value.equalsIgnoreCase(values.toValue())) {
                     return values;
+                }
             }
 
             throw new IllegalArgumentException("ActionType with value " + value + " does not exist.");


### PR DESCRIPTION
Hi Mariam,

We are still using your Kafka river at Linagora, but due to concurency issues, our needs have evolved : 

Where before using Bulk and Raw messages was enough, we now have to perform DeleteByQuery ( for performance purpose ) and we need all our request to be sent to the Kafka queue ( for concurency issue and avoid slow indexation ).

That's why we extended your river, adding a Generic request. That's simply Json representing a request. This Json is analysed by the GenericRequestProducer. It calls then the good API.

As we just need Bulk and DeleteByQuery ( that is not bulkable ie not a raw message ) we just implemented these features. If you want me to add more support ( ie Update by query ) just ask for it. I thought this might interest other people getting stuck because Delete By Query is not bulkable.

Kind regards,

Benoit Tellier from Linagora
