### PR TITLE
Set ES document's ID to a field in the JSON property bag.

### DIFF
--- a/src/main/java/org/elasticsearch/river/kafka/IndexDocumentProducer.java
+++ b/src/main/java/org/elasticsearch/river/kafka/IndexDocumentProducer.java
@@ -69,9 +69,18 @@ public class IndexDocumentProducer extends ElasticSearchProducer {
                         break;
                     case JSON:
                         final Map<String, Object> messageMap = reader.readValue(messageBytes);
+
+                        String id;
+                        if (messageMap.containsKey("id")) {
+                            id = (String)messageMap.get("id");
+                            messageMap.remove("id");
+                        } else {
+                            id = UUID.randomUUID().toString();
+                        }                       
+
                         request = Requests.indexRequest(riverConfig.getIndexName()).
                                 type(riverConfig.getTypeName()).
-                                id(UUID.randomUUID().toString()).
+                                id(id).
                                 source(messageMap);
                 }
 

--- a/src/main/java/org/elasticsearch/river/kafka/IndexDocumentProducer.java
+++ b/src/main/java/org/elasticsearch/river/kafka/IndexDocumentProducer.java
@@ -71,9 +71,9 @@ public class IndexDocumentProducer extends ElasticSearchProducer {
                         final Map<String, Object> messageMap = reader.readValue(messageBytes);
 
                         String id;
-                        if (messageMap.containsKey("id")) {
-                            id = (String)messageMap.get("id");
-                            messageMap.remove("id");
+                        if (messageMap.containsKey("_id")) {
+                            id = (String)messageMap.get("_id");
+                            messageMap.remove("_id");
                         } else {
                             id = UUID.randomUUID().toString();
                         }                       


### PR DESCRIPTION
Allows for stable identification of documents.