### PR TITLE
update the Version of ElasticSearch and Kafka

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ The bulk size (the number of messages to be indexed in one request) and concurre
 The Kafka River also supports consuming messages from multiple Kafka brokers and multiple partitions. 
 
 The plugin uses the latest Kafka and Elasticsearch version.
- * Kafka version 0.8.1.1
- * Elasticsearch version 1.4.0
+ * Kafka version 0.8.2.0
+ * Elasticsearch version 1.4.4
 
 The plugin is periodically updated, if there are newer versions of any dependencies.
 It is available in the [ElasticSearch's official website](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-plugins.html).

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <skipSigning>true</skipSigning>
 
         <!--Dependency versions-->
-        <version.elasticsearch>1.4.0</version.elasticsearch>
-        <version.kafka>0.8.1.1</version.kafka>
+        <version.elasticsearch>1.4.4</version.elasticsearch>
+        <version.kafka>0.8.2.0</version.kafka>
         <version.scala>2.9.2</version.scala>
         <version.slf4j>1.7.2</version.slf4j>
         <version.yammer.metrics.core>2.2.0</version.yammer.metrics.core>
@@ -160,6 +160,9 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.maven.failsafe.plugin}</version>
+                <configuration>
+                	<encoding>UTF-8</encoding>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Several micro adjuments:

* Update the version of ElasticSearch to 1.4.4;
* Update the  version of Kafka to 0.8.2.0; 
* Solve the Warn info when compile the program.(the Warn Info is list below)


Warn info:

	$mvn clean insatll
	...
	[INFO] --- maven-failsafe-plugin:2.14:integration-test (default) @ elasticsearch-river-kafka ---
	[INFO] No tests to run.
	[WARNING] File encoding has not been set, using platform encoding GBK, i.e. build is platform dependent!
	...
